### PR TITLE
Add ability to read full ETS exports in addition to GroupAddress exports

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -35,7 +35,7 @@ func main() {
 	utils.SetupLogging(cfg.LogLevel, cfg.KNX.EnableLogs)
 
 	if cfg.KNX.ETSExport != "" {
-		knxItems, err = parser.ParseGroupAddressExport(cfg.KNX.ETSExport)
+		knxItems, err = parser.ReadGroupsFromFile(cfg.KNX.ETSExport, cfg.KNX.GaTranslation)
 		if err != nil {
 			log.Fatal().Str("error", fmt.Sprintf("%+v", err)).Msg("Error parsing KNX XML")
 			os.Exit(1)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -46,6 +46,17 @@ knx:
   # Enables logging from the KNX library
   enableLogs: false
 
+  # Translate flat group addresses to a specific format
+  # Can be specified as an integer:
+  #   0 = No translation (flat address)
+  #   1 = 2-part notation (main/sub)
+  #   2 = 3-part notation (main/middle/sub)
+  # Or as a string (case-insensitive):
+  #   "none" or "flat" = No translation (flat address)
+  #   "2-part" or "two-part" = 2-part notation (main/sub)
+  #   "3-part" or "three-part" = 3-part notation (main/middle/sub)
+  translateFlatGroupAddresses: "3-part"
+
 mqtt:
   # URL to MQTT broker
   #url: 'ssl://localhost:8883'

--- a/internal/knx/client.go
+++ b/internal/knx/client.go
@@ -58,7 +58,12 @@ func (c *KNXClient) connect() *error {
 
 func (c *KNXClient) newMessage(event knxgo.GroupEvent) *msg.KNXMessage {
 	destination := event.Destination.String()
-	index, exists := c.knxItems.GadToIndex[destination]
+	flatDestination, err := models.ParseGroupAddress(destination)
+	if err != nil {
+		log.Error().Err(err).Str("address", destination).Msg("Failed to parse KNX group address")
+		return msg.NewKNX(event, nil, nil)
+	}
+	index, exists := c.knxItems.GadToIndex[flatDestination]
 	if !exists {
 		return msg.NewKNX(event, nil, nil)
 	}

--- a/internal/models/config.go
+++ b/internal/models/config.go
@@ -31,11 +31,12 @@ type IncludedJsonFields struct {
 
 // KNXConfig represents the KNX configuration section.
 type KNXConfig struct {
-	ETSExport                   string `yaml:"etsExport"`
-	Endpoint                    string `yaml:"endpoint"`
-	TunnelMode                  bool   `yaml:"tunnelMode"`
-	IgnoreUnknownGroupAddresses bool   `yaml:"ignoreUnknownGroupAddresses"`
-	EnableLogs                  bool   `yaml:"enableLogs"`
+	ETSExport                   string                 `yaml:"etsExport"`
+	Endpoint                    string                 `yaml:"endpoint"`
+	TunnelMode                  bool                   `yaml:"tunnelMode"`
+	IgnoreUnknownGroupAddresses bool                   `yaml:"ignoreUnknownGroupAddresses"`
+	EnableLogs                  bool                   `yaml:"enableLogs"`
+	GaTranslation               FlatAddressTranslation `yaml:"translateFlatGroupAddresses"`
 }
 
 // MQTTConfig represents the MQTT configuration section.

--- a/internal/models/knx.go
+++ b/internal/models/knx.go
@@ -2,27 +2,34 @@ package models
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/pakerfeldt/knx-mqtt/internal/utils"
+	"gopkg.in/yaml.v3"
 )
 
+type FlatGroupAddress uint16
+
 type GroupAddress struct {
-	FullName  string
-	Name      string
-	Address   string
-	Datapoint string
+	FullName    string
+	Name        string
+	Address     string
+	FlatAddress FlatGroupAddress
+	Datapoint   string
 }
 
 type KNX struct {
 	NameToIndex    map[string]int
-	GadToIndex     map[string]int
+	GadToIndex     map[FlatGroupAddress]int
 	GroupAddresses []GroupAddress
 }
 
 func EmptyKNX() KNX {
 	return KNX{
 		NameToIndex:    make(map[string]int),
-		GadToIndex:     make(map[string]int),
+		GadToIndex:     make(map[FlatGroupAddress]int),
 		GroupAddresses: []GroupAddress{},
 	}
 }
@@ -31,14 +38,15 @@ func (k *KNX) AddGroupAddress(groupAddress GroupAddress) {
 	k.GroupAddresses = append(k.GroupAddresses, groupAddress)
 	index := len(k.GroupAddresses) - 1
 	k.NameToIndex[groupAddress.FullName] = index
-	k.GadToIndex[groupAddress.Address] = index
+	k.GadToIndex[groupAddress.FlatAddress] = index
 }
 
 func (k *KNX) GetGroupAddress(address string) (*GroupAddress, bool) {
 	var index int
 	var exists bool
-	if utils.IsRegularGroupAddress(address) {
-		index, exists = k.GadToIndex[address]
+	if utils.IsRegularOrFlatGroupAddress(address) {
+		flatAddr, _ := ParseGroupAddress(address)
+		index, exists = k.GadToIndex[flatAddr]
 	} else {
 		index, exists = k.NameToIndex[address]
 	}
@@ -59,4 +67,176 @@ func (k *KNX) Is(address GroupAddress) error {
 type KNXInterface interface {
 	AddGroupAddress(address GroupAddress) error
 	GetGroupAddress(name string) (*GroupAddress, error)
+}
+
+// ParseGroupAddress parses a group-address in either plain notation (i.e. 0-65535),
+// 2-part notation ("31/2047") or 3-part notation ("31/7/255")
+// and returns it as a flat uint16 address and an error if parsing fails
+func ParseGroupAddress(ga string) (FlatGroupAddress, error) {
+	if ga == "" {
+		return 0, fmt.Errorf("group address cannot be empty")
+	}
+
+	// Check if the address contains slashes (indicating 2-part or 3-part format)
+	if strings.Contains(ga, "/") {
+		parts := strings.Split(ga, "/")
+
+		// Handle invalid number of parts
+		if len(parts) != 2 && len(parts) != 3 {
+			return 0, fmt.Errorf("invalid group address format: expected 2 or 3 parts, got %d parts", len(parts))
+		}
+
+		// Parse the first part (leftmost 5 bits) - common to both formats
+		main, err := strconv.ParseUint(parts[0], 10, 16)
+		if err != nil {
+			return 0, fmt.Errorf("invalid main part '%s': %w", parts[0], err)
+		}
+
+		// Validate main part (5 bits: 0-31)
+		if main > 31 {
+			return 0, fmt.Errorf("main part '%d' exceeds maximum value of 31 (5 bits)", main)
+		}
+
+		// Shift the main part to the leftmost 5 bits position
+		mainPart := uint16(main << 11)
+
+		if len(parts) == 2 {
+			// 2-part representation: main/sub (5 bits / 11 bits)
+			sub, err := strconv.ParseUint(parts[1], 10, 16)
+			if err != nil {
+				return 0, fmt.Errorf("invalid sub part '%s': %w", parts[1], err)
+			}
+
+			// Validate sub part (11 bits: 0-2047)
+			if sub > 2047 {
+				return 0, fmt.Errorf("sub part '%d' exceeds maximum value of 2047 (11 bits)", sub)
+			}
+
+			return FlatGroupAddress(mainPart | uint16(sub)), nil
+		} else if len(parts) == 3 {
+			// 3-part representation: main/middle/sub (5 bits / 3 bits / 8 bits)
+			middle, err := strconv.ParseUint(parts[1], 10, 16)
+			if err != nil {
+				return 0, fmt.Errorf("invalid middle part '%s': %w", parts[1], err)
+			}
+
+			// Validate middle part (3 bits: 0-7)
+			if middle > 7 {
+				return 0, fmt.Errorf("middle part '%d' exceeds maximum value of 7 (3 bits)", middle)
+			}
+
+			sub, err := strconv.ParseUint(parts[2], 10, 16)
+			if err != nil {
+				return 0, fmt.Errorf("invalid sub part '%s': %w", parts[2], err)
+			}
+
+			// Validate sub part (8 bits: 0-255)
+			if sub > 255 {
+				return 0, fmt.Errorf("sub part '%d' exceeds maximum value of 255 (8 bits)", sub)
+			}
+
+			// Shift middle to its position (bits 8-10) and combine with main and sub
+			middlePart := uint16(middle << 8)
+			return FlatGroupAddress(mainPart | middlePart | uint16(sub)), nil
+		}
+	} else {
+		// Direct plain address format
+		flatAddr, err := strconv.ParseUint(ga, 10, 16)
+		if err != nil {
+			return 0, fmt.Errorf("invalid plain address format '%s': %w", ga, err)
+		}
+
+		// Ensure the value fits in uint16
+		if flatAddr > 65535 {
+			return 0, fmt.Errorf("plain address '%d' exceeds maximum value of 65535 (16 bits)", flatAddr)
+		}
+
+		return FlatGroupAddress(flatAddr), nil
+	}
+	return 0, fmt.Errorf("invalid group address format")
+}
+
+type FlatAddressTranslation int
+
+const (
+	FAT_None FlatAddressTranslation = iota
+	FAT_2_parts
+	FAT_3_parts
+)
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for FlatAddressTranslation
+func (fat *FlatAddressTranslation) UnmarshalYAML(value *yaml.Node) error {
+	// Try to unmarshal as an integer first (for backward compatibility)
+	var intValue int
+	if err := value.Decode(&intValue); err == nil {
+		switch intValue {
+		case 0:
+			*fat = FAT_None
+		case 1:
+			*fat = FAT_2_parts
+		case 2:
+			*fat = FAT_3_parts
+		default:
+			return fmt.Errorf("invalid FlatAddressTranslation value: %d", intValue)
+		}
+		return nil
+	}
+
+	// If not an integer, try to unmarshal as a string
+	var stringValue string
+	if err := value.Decode(&stringValue); err != nil {
+		return fmt.Errorf("FlatAddressTranslation must be an integer or a string: %w", err)
+	}
+
+	// Convert string to lowercase for case-insensitive comparison
+	switch strings.ToLower(stringValue) {
+	case "none", "flat":
+		*fat = FAT_None
+	case "2-part", "two-part":
+		*fat = FAT_2_parts
+	case "3-part", "three-part":
+		*fat = FAT_3_parts
+	default:
+		return fmt.Errorf("invalid FlatAddressTranslation string value: %s", stringValue)
+	}
+
+	return nil
+}
+
+func TranslateFlatAddress(fga FlatGroupAddress, translation FlatAddressTranslation) string {
+	// Convert the flat address to uint16 for bit manipulation
+	flatAddr := uint16(fga)
+
+	switch translation {
+	case FAT_None:
+		// Return the flat address as a string without any translation
+		return strconv.FormatUint(uint64(flatAddr), 10)
+
+	case FAT_2_parts:
+		// Extract the main part (5 leftmost bits)
+		main := (flatAddr >> 11) & 0x1F // 0x1F = 31 (5 bits)
+
+		// Extract the sub part (11 rightmost bits)
+		sub := flatAddr & 0x7FF // 0x7FF = 2047 (11 bits)
+
+		// Format as "main/sub"
+		return fmt.Sprintf("%d/%d", main, sub)
+
+	case FAT_3_parts:
+		// Extract the main part (5 leftmost bits)
+		main := (flatAddr >> 11) & 0x1F // 0x1F = 31 (5 bits)
+
+		// Extract the middle part (3 bits after main)
+		middle := (flatAddr >> 8) & 0x07 // 0x07 = 7 (3 bits)
+
+		// Extract the sub part (8 rightmost bits)
+		sub := flatAddr & 0xFF // 0xFF = 255 (8 bits)
+
+		// Format as "main/middle/sub"
+		return fmt.Sprintf("%d/%d/%d", main, middle, sub)
+
+	default:
+		// For any unrecognized translation, return the flat address
+		return strconv.FormatUint(uint64(flatAddr), 10)
+	}
 }

--- a/internal/models/knx_test.go
+++ b/internal/models/knx_test.go
@@ -1,0 +1,154 @@
+package models
+
+import (
+	"testing"
+)
+
+func TestParseGroupAddress(t *testing.T) {
+	// Test cases for valid inputs
+	tests := []struct {
+		name    string
+		address string
+		want    FlatGroupAddress
+	}{
+		// Direct plain address format
+		{
+			name:    "Direct plain address",
+			address: "12345",
+			want:    12345,
+		},
+		{
+			name:    "Direct plain address zero",
+			address: "0",
+			want:    0,
+		},
+		// 2-part representation (main/sub)
+		{
+			name:    "2-part: main=0, sub=0",
+			address: "0/0",
+			want:    0,
+		},
+		{
+			name:    "2-part: main=1, sub=0",
+			address: "1/0",
+			want:    1 << 11, // 2048
+		},
+		{
+			name:    "2-part: main=0, sub=1",
+			address: "0/1",
+			want:    1,
+		},
+		{
+			name:    "2-part: main=15, sub=2047",
+			address: "15/2047",
+			want:    FlatGroupAddress((15 << 11) | 2047), // 32767
+		},
+		// 3-part representation (main/middle/sub)
+		{
+			name:    "3-part: main=0, middle=0, sub=0",
+			address: "0/0/0",
+			want:    0,
+		},
+		{
+			name:    "3-part: main=1, middle=0, sub=0",
+			address: "1/0/0",
+			want:    1 << 11, // 2048
+		},
+		{
+			name:    "3-part: main=0, middle=1, sub=0",
+			address: "0/1/0",
+			want:    1 << 8, // 256
+		},
+		{
+			name:    "3-part: main=0, middle=0, sub=1",
+			address: "0/0/1",
+			want:    1,
+		},
+		{
+			name:    "3-part: main=15, middle=7, sub=255",
+			address: "15/7/255",
+			want:    FlatGroupAddress((15 << 11) | (7 << 8) | 255), // 32767
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGroupAddress(tt.address)
+			if err != nil {
+				t.Errorf("ParseGroupAddress(%q) error = %v, want no error", tt.address, err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseGroupAddress(%q) = %v, want %v", tt.address, got, tt.want)
+			}
+		})
+	}
+
+	// Test cases for invalid inputs
+	errorTests := []struct {
+		name    string
+		address string
+	}{
+		{
+			name:    "Empty string",
+			address: "",
+		},
+		{
+			name:    "Invalid format - non-numeric",
+			address: "abc",
+		},
+		{
+			name:    "Invalid 2-part - non-numeric main",
+			address: "a/123",
+		},
+		{
+			name:    "Invalid 2-part - non-numeric sub",
+			address: "1/abc",
+		},
+		{
+			name:    "Invalid 3-part - non-numeric main",
+			address: "a/1/123",
+		},
+		{
+			name:    "Invalid 3-part - non-numeric middle",
+			address: "1/a/123",
+		},
+		{
+			name:    "Invalid 3-part - non-numeric sub",
+			address: "1/2/abc",
+		},
+		{
+			name:    "Invalid 2-part - main too large",
+			address: "32/123", // main > 31 (5 bits)
+		},
+		{
+			name:    "Invalid 2-part - sub too large",
+			address: "1/2048", // sub > 2047 (11 bits)
+		},
+		{
+			name:    "Invalid 3-part - main too large",
+			address: "32/1/123", // main > 31 (5 bits)
+		},
+		{
+			name:    "Invalid 3-part - middle too large",
+			address: "1/8/123", // middle > 7 (3 bits)
+		},
+		{
+			name:    "Invalid 3-part - sub too large",
+			address: "1/2/256", // sub > 255 (8 bits)
+		},
+		{
+			name:    "Too many parts",
+			address: "1/2/3/4",
+		},
+	}
+
+	for _, tt := range errorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGroupAddress(tt.address)
+			if err == nil {
+				t.Errorf("ParseGroupAddress(%q) = %v, want error", tt.address, got)
+			}
+		})
+	}
+}

--- a/internal/models/knx_translation_test.go
+++ b/internal/models/knx_translation_test.go
@@ -1,0 +1,141 @@
+package models
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestFlatAddressTranslationUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name     string
+		yamlStr  string
+		expected FlatAddressTranslation
+		wantErr  bool
+	}{
+		{
+			name:     "Integer 0",
+			yamlStr:  "0",
+			expected: FAT_None,
+			wantErr:  false,
+		},
+		{
+			name:     "Integer 1",
+			yamlStr:  "1",
+			expected: FAT_2_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "Integer 2",
+			yamlStr:  "2",
+			expected: FAT_3_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid Integer",
+			yamlStr:  "3",
+			expected: 0,
+			wantErr:  true,
+		},
+		{
+			name:     "String 'none'",
+			yamlStr:  "none",
+			expected: FAT_None,
+			wantErr:  false,
+		},
+		{
+			name:     "String 'flat'",
+			yamlStr:  "flat",
+			expected: FAT_None,
+			wantErr:  false,
+		},
+		{
+			name:     "String '2-part'",
+			yamlStr:  "2-part",
+			expected: FAT_2_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "String 'two-part'",
+			yamlStr:  "two-part",
+			expected: FAT_2_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "String '3-part'",
+			yamlStr:  "3-part",
+			expected: FAT_3_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "String 'three-part'",
+			yamlStr:  "three-part",
+			expected: FAT_3_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "Case insensitive 'NONE'",
+			yamlStr:  "NONE",
+			expected: FAT_None,
+			wantErr:  false,
+		},
+		{
+			name:     "Case insensitive 'Three-Part'",
+			yamlStr:  "Three-Part",
+			expected: FAT_3_parts,
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid string",
+			yamlStr:  "invalid",
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var fat FlatAddressTranslation
+			err := yaml.Unmarshal([]byte(tt.yamlStr), &fat)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalYAML() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && fat != tt.expected {
+				t.Errorf("UnmarshalYAML() got = %v, want %v", fat, tt.expected)
+			}
+		})
+	}
+}
+
+func TestFlatAddressTranslationInConfig(t *testing.T) {
+	// Test with integer value
+	yamlWithInt := `
+knx:
+  translateFlatGroupAddresses: 2
+`
+	var configInt Config
+	err := yaml.Unmarshal([]byte(yamlWithInt), &configInt)
+	if err != nil {
+		t.Errorf("Failed to unmarshal config with integer: %v", err)
+	}
+	if configInt.KNX.GaTranslation != FAT_3_parts {
+		t.Errorf("Expected FAT_3_parts (2), got %v", configInt.KNX.GaTranslation)
+	}
+
+	// Test with string value
+	yamlWithString := `
+knx:
+  translateFlatGroupAddresses: "two-part"
+`
+	var configString Config
+	err = yaml.Unmarshal([]byte(yamlWithString), &configString)
+	if err != nil {
+		t.Errorf("Failed to unmarshal config with string: %v", err)
+	}
+	if configString.KNX.GaTranslation != FAT_2_parts {
+		t.Errorf("Expected FAT_2_parts (1), got %v", configString.KNX.GaTranslation)
+	}
+}

--- a/internal/models/xml.go
+++ b/internal/models/xml.go
@@ -1,18 +1,51 @@
 package models
 
+import (
+	"encoding/xml"
+)
+
+// // XmlETSRoot represents the root ETS file export
+// type XmlETSRoot struct {
+// 	KNX XmlKNX `xml:"KNX"`
+// }
+
+// XmlKNX represents the root KNX element
+type XmlKNX struct {
+	XMLName xml.Name   `xml:"KNX"`
+	Project XmlProject `xml:"Project"`
+}
+
+// XmlProject represents the Project element
+type XmlProject struct {
+	Installations []XmlInstallation `xml:"Installations>Installation"`
+}
+
+// XmlInstallation represents the Installation element
+type XmlInstallation struct {
+	Name           string `xml:",attr"`
+	GroupAddresses XmlGroupAddresses
+}
+
+// XmlGroupAddresses represents the GroupAddresses element
+type XmlGroupAddresses struct {
+	GroupRanges XmlGroupAddressExport `xml:"GroupRanges"`
+}
+
+// XmlGroupAddressExport represents the GroupRanges element for direct export format
 type XmlGroupAddressExport struct {
-    GroupRanges []XmlGroupRange `xml:"GroupRange"`
+	GroupRanges []XmlGroupRange `xml:"GroupRange"`
 }
 
 type XmlGroupRange struct {
-    Name        string        `xml:"Name,attr"`
-    GroupRanges []XmlGroupRange  `xml:"GroupRange"`    // For nested GroupRanges
-    Addresses   []XmlGroupAddress `xml:"GroupAddress"` // For GroupAddresses
+	Name        string            `xml:"Name,attr"`
+	GroupRanges []XmlGroupRange   `xml:"GroupRange"`   // For nested GroupRanges
+	Addresses   []XmlGroupAddress `xml:"GroupAddress"` // For GroupAddresses
 }
 
 type XmlGroupAddress struct {
-    Name        string `xml:"Name,attr"`
-    Address     string `xml:"Address,attr"`
-    DPTs        string `xml:"DPTs,attr,omitempty"`
-    Description string `xml:"Description,attr,omitempty"`
+	Name          string `xml:"Name,attr"`
+	Address       string `xml:"Address,attr"`
+	DPTs          string `xml:"DPTs,attr,omitempty"`          // DPTs is the attribute's name in group address exports
+	DatapointType string `xml:"DatapointType,attr,omitempty"` // DatapointType is the attribute's name in ETS exports
+	Description   string `xml:"Description,attr,omitempty"`
 }

--- a/internal/parser/xml_parser.go
+++ b/internal/parser/xml_parser.go
@@ -1,35 +1,72 @@
 package parser
 
 import (
+	"archive/zip"
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
 	"github.com/pakerfeldt/knx-mqtt/internal/models"
+	"github.com/pakerfeldt/knx-mqtt/internal/utils"
 	"github.com/rs/zerolog/log"
 )
 
 var regexpDpt = regexp.MustCompile(`DPST-(\d+)-(\d+)`)
 
-func ParseGroupAddressExport(filePath string) (*models.KNX, error) {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
+// FileID represents the type of KNX file being processed
+type FileID int
 
-	byteValue, err := io.ReadAll(file)
+const (
+	// NA - not applicable, i.e. no file was ID'd
+	NA FileID = iota
+
+	// GroupAddressExport represents a KNX group address export file
+	GroupAddressExport
+	// ETSExport represents an ETS project export file
+	ETSExport
+)
+
+func ReadGroupsFromFile(filePath string, gaTranslation models.FlatAddressTranslation) (*models.KNX, error) {
+	fileid, byteValue, err := readAndIDFile(filePath)
 	if err != nil {
 		return nil, err
 	}
 
 	var export models.XmlGroupAddressExport
-	err = xml.Unmarshal(byteValue, &export)
-	if err != nil {
-		return nil, err
+
+	switch fileid {
+	case GroupAddressExport:
+		log.Info().Msgf("%s identified as a group address export", filePath)
+		err = xml.Unmarshal(byteValue, &export)
+		if err != nil {
+			return nil, err
+		}
+
+	case ETSExport:
+		log.Info().Msgf("%s identified as a ETS export", filePath)
+		var knxfile models.XmlKNX
+		err = xml.Unmarshal(byteValue, &knxfile)
+		if err != nil {
+			return nil, err
+		}
+		installations := knxfile.Project.Installations
+		if len(installations) == 0 {
+			return nil, fmt.Errorf("no installations in ETS file")
+		} else if len(installations) > 1 {
+			log.Info().Msgf("Found multiple installations in ETS file; using the first one: \"%s\"", installations[0].Name)
+		}
+		export = installations[0].GroupAddresses.GroupRanges
+
+		// Translate DatapointType -> DPTs
+		translateDatapointTypeToDPTs(&export)
+
+	default:
+		return nil, fmt.Errorf("cannot handle file type %v", fileid)
 	}
 
 	knxItems := models.EmptyKNX()
@@ -40,17 +77,104 @@ func ParseGroupAddressExport(filePath string) (*models.KNX, error) {
 					log.Warn().Msgf("%s with address %s did not have a DPT specified and will be ignored", address.Name, address.Address)
 					continue
 				}
+				flatAddr, err := models.ParseGroupAddress(address.Address)
+				if err != nil {
+					return nil, err
+				}
+				translatedAddr := address.Address
+				if utils.IsFlatGroupAddress(address.Address) {
+					translatedAddr = models.TranslateFlatAddress(flatAddr, gaTranslation)
+				}
 				knxItems.AddGroupAddress(models.GroupAddress{
-					Name:      address.Name,
-					FullName:  fmt.Sprintf("%s/%s/%s", main.Name, middle.Name, replaceSlashInName(address.Name)),
-					Address:   address.Address,
-					Datapoint: convertDptFormat(address.DPTs),
+					Name:        address.Name,
+					FullName:    fmt.Sprintf("%s/%s/%s", main.Name, middle.Name, replaceSlashInName(address.Name)),
+					Address:     translatedAddr,
+					FlatAddress: flatAddr,
+					Datapoint:   convertDptFormat(address.DPTs),
 				})
 			}
 		}
 	}
 
 	return &knxItems, nil
+}
+
+func readAndIDFile(filePath string) (FileID, []byte, error) {
+	fid := NA
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fid, nil, err
+	}
+	defer file.Close()
+
+	// bufreader := bufio.NewReader(file)
+	magic := make([]byte, 4)
+	n, err := file.Read(magic)
+	if err != nil {
+		return fid, nil, err
+	}
+
+	// Reset file position to beginning
+	_, err = file.Seek(0, 0)
+	if err != nil {
+		return fid, nil, err
+	}
+
+	var maybeZipReader io.Reader
+	maybeZipReader = file
+
+	// Check if magic equals the ZIP signature 50 4b 03 04
+	// If so, assume this is a ETS project export and look for 0.xml
+	zipSignature := []byte{0x50, 0x4b, 0x03, 0x04}
+	if n == 4 && bytes.Equal(magic, zipSignature) {
+		log.Debug().Msg("ZIP signature detected, using gzip reader")
+
+		rc, err := findGroupsInZip(file)
+		if err != nil {
+			return fid, nil, err
+		}
+		defer rc.Close()
+		maybeZipReader = rc
+		fid = ETSExport
+	} else {
+		fid = GroupAddressExport
+	}
+
+	byteValue, err := io.ReadAll(maybeZipReader)
+	if err != nil {
+		return fid, nil, err
+	}
+	return fid, byteValue, nil
+}
+
+func findGroupsInZip(file *os.File) (io.ReadCloser, error) {
+	fs, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a gzip reader
+	zipReader, err := zip.NewReader(file, fs.Size())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gzip reader: %w", err)
+	}
+
+	// Find a file "0.xml" in any path within the ZIP file
+	for _, f := range zipReader.File {
+		// Check if the file name is exactly "0.xml" at any path level
+		if filepath.Base(f.Name) == "0.xml" {
+			log.Debug().Msgf("Found 0.xml at path: %s", f.Name)
+
+			rc, err := f.Open()
+			if err != nil {
+				return nil, fmt.Errorf("failed to open 0.xml file: %w", err)
+			}
+
+			return rc, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no 0.xml file found in the ZIP archive")
 }
 
 func replaceSlashInName(name string) string {
@@ -68,4 +192,29 @@ func convertDptFormat(dpt string) string {
 		return fmt.Sprintf("%s.%03s", match[1], match[2])
 	}
 	return ""
+}
+
+// translateDatapointTypeToDPTs iterates over all XmlGroupAddress objects nested inside export
+// and checks if DPTs is empty. If so, it sets DPTs = DatapointType
+func translateDatapointTypeToDPTs(export *models.XmlGroupAddressExport) {
+	// Process each top-level GroupRange
+	for i := range export.GroupRanges {
+		translateGroupRange(&export.GroupRanges[i])
+	}
+}
+
+// translateGroupRange recursively processes a GroupRange and its nested elements
+func translateGroupRange(groupRange *models.XmlGroupRange) {
+	// Process addresses at this level
+	for i := range groupRange.Addresses {
+		address := &groupRange.Addresses[i]
+		if address.DPTs == "" && address.DatapointType != "" {
+			address.DPTs = address.DatapointType
+		}
+	}
+
+	// Recursively process nested GroupRanges
+	for i := range groupRange.GroupRanges {
+		translateGroupRange(&groupRange.GroupRanges[i])
+	}
 }

--- a/internal/utils/knx_utils.go
+++ b/internal/utils/knx_utils.go
@@ -10,7 +10,9 @@ import (
 	"github.com/vapourismo/knx-go/knx/dpt"
 )
 
-var regexpGad = regexp.MustCompile(`\d+\/\d+\/\d+`)
+var regexpGad = regexp.MustCompile(`^\d+\/\d+\/\d+$`)
+var regexpGadOrFlat = regexp.MustCompile(`^\d+\/\d+\/\d+|\d+$`)
+var regexpFlatGad = regexp.MustCompile(`^\d+$`)
 
 var regexpTimeOfDay = regexp.MustCompile(`^(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)?\s*(\d{2}):(\d{2}):(\d{2})$`)
 var regexpDate = regexp.MustCompile(`^(\d{4})-(\d{2})-(\d{2})$`)
@@ -25,6 +27,14 @@ var weekdays = map[string]uint8{
 
 func IsRegularGroupAddress(address string) bool {
 	return regexpGad.MatchString(address)
+}
+
+func IsFlatGroupAddress(address string) bool {
+	return regexpFlatGad.MatchString(address)
+}
+
+func IsRegularOrFlatGroupAddress(address string) bool {
+	return regexpGadOrFlat.MatchString(address)
 }
 
 func PackString(datatype string, value string) ([]byte, error) {


### PR DESCRIPTION
This implements feature request #5 
Note: I've only tested this with one project file exported out of ETS 6.3.0. Before merging this, it would be great if others could test it with their .knxproj exports.